### PR TITLE
Allow the extension to be used with different file extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the "vue-discovery" extension will be documented in this file.
 ## [Unreleased]
 
+## [1.5.0] 2020-07-06
+### Added
+- Add configuration option to make the extension work with different file extensions.
+
 ## [1.4.0] 2020-05-21
 ### Added
 - IntelliSense for events

--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ This extension discovers Vue components in your workspace and provides IntelliSe
 
 This extension can be customized with the following settings:
 
-* `vueDiscovery.rootDirectory`: this tells where to look for vue components (default: `src`)
+* `vueDiscovery.rootDirectory`: This tells where to look for vue components (default: `src`)
 * `vueDiscovery.componentCase`: The casing for the component, available options are `kebab` for kebab-case and `pascal` for PascalCase (default: `pascal`)
 * `vueDiscovery.addTrailingComma`: Add a trailing comma to the registered component (default: `true`)
 * `vueDiscovery.propCase`: The casing for the props, available options are `kebab` for kebab-case and `camel` for camelCase (default: `kebab`)
+* `vueDiscovery.extensions`: An array of file extensions Vue discovery will be active in, .vue is always active. (default: `null`)
 
 ## 🔖 Release Notes
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "vueDiscovery.rootDirectory": {
           "type": "string",
           "default": "/src",
-          "description": "root directory in your workspace"
+          "description": "Root directory in your workspace."
         },
         "vueDiscovery.componentCase": {
           "type": "string",
@@ -33,12 +33,20 @@
             "kebab"
           ],
           "default": "pascal",
-          "description": "The casing of the imported component"
+          "description": "The casing of the imported component."
         },
         "vueDiscovery.addTrailingComma": {
           "type": "boolean",
           "default": true,
           "description": "Add a trailing comma"
+        },
+        "vueDiscovery.extensions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "default": null,
+          "description": "File extensions Vue discovery will be active in."
         },
         "vueDiscovery.propCase": {
           "type": "string",
@@ -47,7 +55,7 @@
             "kebab"
           ],
           "default": "kebab",
-          "description": "The casing of the props"
+          "description": "The casing of the props."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This extension discovers Vue components in your workspace and provides IntelliSense for them.",
   "publisher": "maantje",
   "repository": "https://github.com/maantje/vue-discovery",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "icon": "images/icon.png",
   "engines": {
     "vscode": "^1.44.0"

--- a/test/fixture/src/different-extension.blade.php
+++ b/test/fixture/src/different-extension.blade.php
@@ -1,0 +1,14 @@
+<html>
+    <head>
+        <title>App Name - @yield('title')</title>
+    </head>
+    <body>
+        @section('sidebar')
+            This is the master sidebar.
+        @show
+
+        <div class="container">
+            @yield('content')
+        </div>
+    </body>
+</html>

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,0 +1,34 @@
+const vscode = require('vscode');
+
+const components = [
+    Object.assign(new vscode.CompletionItem('ComponentWithProps', vscode.CompletionItemKind.Constructor), { detail: 'components/ComponentWithProps.vue' }),
+    Object.assign(new vscode.CompletionItem('AnotherComponent', vscode.CompletionItemKind.Constructor), { detail: 'components/AnotherComponent.vue' }),
+    Object.assign(new vscode.CompletionItem('App', vscode.CompletionItemKind.Constructor), { detail: 'src/App.vue' }),
+];
+
+const props = [
+    new vscode.CompletionItem('label', vscode.CompletionItemKind.Variable),
+    new vscode.CompletionItem('defaultValue', vscode.CompletionItemKind.Variable),
+    new vscode.CompletionItem('name', vscode.CompletionItemKind.Variable),
+    new vscode.CompletionItem('names', vscode.CompletionItemKind.Variable),
+];
+
+const events = [
+    new vscode.CompletionItem('eventInComponent', vscode.CompletionItemKind.Event),
+    new vscode.CompletionItem('eventInMixin', vscode.CompletionItemKind.Event),
+    new vscode.CompletionItem('eventInSubMixin', vscode.CompletionItemKind.Event),
+];
+
+const hover = [
+    '(required) name: `String`',
+    '(required) names: `Array`',
+    'label: `String`',
+    '(required) defaultValue: `String`',
+];
+
+module.exports = {
+    components,
+    props,
+    events,
+    hover,
+};

--- a/test/suite/casing.test.js
+++ b/test/suite/casing.test.js
@@ -2,25 +2,8 @@ const assert = require('assert');
 const vscode = require('vscode');
 const { showFile, getDocUri, position, getDocPath, sleep, range } = require('../util');
 const { testLineEquals, rangeEquals, testHover, testCompletion, testCompletionDoesNotContainItems } = require('../helpers');
+const { components, props, events, hover } = require('../fixtures');
 
-const components = [
-    Object.assign(new vscode.CompletionItem('ComponentWithProps', vscode.CompletionItemKind.Constructor), { detail: 'components/ComponentWithProps.vue' }),
-    Object.assign(new vscode.CompletionItem('AnotherComponent', vscode.CompletionItemKind.Constructor), { detail: 'components/AnotherComponent.vue' }),
-    Object.assign(new vscode.CompletionItem('App', vscode.CompletionItemKind.Constructor), { detail: 'src/App.vue' }),
-];
-
-const props = [
-    new vscode.CompletionItem('label', vscode.CompletionItemKind.Variable),
-    new vscode.CompletionItem('defaultValue', vscode.CompletionItemKind.Variable),
-    new vscode.CompletionItem('name', vscode.CompletionItemKind.Variable),
-    new vscode.CompletionItem('names', vscode.CompletionItemKind.Variable),
-];
-
-const events = [
-    new vscode.CompletionItem('eventInComponent', vscode.CompletionItemKind.Event),
-    new vscode.CompletionItem('eventInMixin', vscode.CompletionItemKind.Event),
-    new vscode.CompletionItem('eventInSubMixin', vscode.CompletionItemKind.Event),
-];
 
 describe('Interactions', function () {
     const docUri = getDocUri('App.vue');
@@ -67,12 +50,7 @@ describe('Interactions', function () {
 
     it('shows props when hovering a component', async () => {
         await testHover(docUri, position(3, 10), {
-            contents: [
-                '(required) name: String',
-                '(required) names: Array',
-                'label: String',
-                '(required) defaultValue: String',
-            ],
+            contents: hover,
         });
     });
 

--- a/test/suite/extension.test.js
+++ b/test/suite/extension.test.js
@@ -2,25 +2,8 @@ const assert = require('assert');
 const vscode = require('vscode');
 const { showFile, getDocUri, position, getDocPath, sleep, range } = require('../util');
 const { testLineEquals, rangeEquals, testHover, testCompletion, testCompletionDoesNotContainItems } = require('../helpers');
+const { components, props, events, hover } = require('../fixtures');
 
-const components = [
-    Object.assign(new vscode.CompletionItem('ComponentWithProps', vscode.CompletionItemKind.Constructor), { detail: 'components/ComponentWithProps.vue' }),
-    Object.assign(new vscode.CompletionItem('AnotherComponent', vscode.CompletionItemKind.Constructor), { detail: 'components/AnotherComponent.vue' }),
-    Object.assign(new vscode.CompletionItem('App', vscode.CompletionItemKind.Constructor), { detail: 'src/App.vue' }),
-];
-
-const props = [
-    new vscode.CompletionItem('label', vscode.CompletionItemKind.Variable),
-    new vscode.CompletionItem('defaultValue', vscode.CompletionItemKind.Variable),
-    new vscode.CompletionItem('name', vscode.CompletionItemKind.Variable),
-    new vscode.CompletionItem('names', vscode.CompletionItemKind.Variable),
-];
-
-const events = [
-    new vscode.CompletionItem('eventInComponent', vscode.CompletionItemKind.Event),
-    new vscode.CompletionItem('eventInMixin', vscode.CompletionItemKind.Event),
-    new vscode.CompletionItem('eventInSubMixin', vscode.CompletionItemKind.Event),
-];
 
 describe('Interactions', function () {
     const docUri = getDocUri('App.vue');
@@ -65,12 +48,7 @@ describe('Interactions', function () {
 
     it('shows props when hovering a component', async () => {
         await testHover(docUri, position(3, 10), {
-            contents: [
-                '(required) name: String',
-                '(required) names: Array',
-                'label: String',
-                '(required) defaultValue: String',
-            ],
+            contents: hover,
         });
     });
 

--- a/test/suite/otherFileExtension.test.js
+++ b/test/suite/otherFileExtension.test.js
@@ -1,0 +1,62 @@
+const vscode = require('vscode');
+const { showFile, getDocUri, position, getDocPath, sleep } = require('../util');
+const { testLineEquals, testHover, testCompletion, testCompletionDoesNotContainItems } = require('../helpers');
+const { components, props, events, hover } = require('../fixtures');
+
+describe('Interactions', function () {
+    const docUri = getDocUri('different-extension.blade.php');
+    const componentWithoutPropsSnippet = '<ComponentWithProps :name="" :names="" :default-value=""></ComponentWithProps>';
+
+    before('activate', async () => {
+        await vscode.commands.executeCommand('vueDiscovery.tests.setConfigOption', 'extensions', ['.blade.php']);
+        await showFile(docUri);
+    });
+
+    it('shows available components', async () => {
+        await testCompletion(docUri, position(8, 8), components);
+    });
+
+    it('adds a component to the template section', async () => {
+        const pos = position(8, 8);
+        const editor = vscode.window.activeTextEditor;
+
+        await editor.edit(edit => {
+            edit.insert(position(8, 0), '\t\t');
+        });
+
+        editor.selection = new vscode.Selection(pos, pos);
+
+        await vscode.commands.executeCommand('vueDiscovery.importFile', getDocPath('components/ComponentWithProps.vue'), 'ComponentWithProps');
+
+        await sleep(50);
+
+        testLineEquals(8, `\t\t${componentWithoutPropsSnippet}`);
+    });
+
+    it('shows props when hovering a component', async () => {
+        await testHover(docUri, position(8, 10), {
+            contents: hover,
+        });
+    });
+
+    it('does not show available components when inside attributes', async () => {
+        await testCompletionDoesNotContainItems(docUri, position(8, 40), components);
+    });
+
+    it('completes props and events on a component', async () => {
+        await testCompletion(docUri, position(8, 40), [...props, ...events]);
+    });
+
+    it('adds the same component to the template section', async () => {
+        const pos = position(8, componentWithoutPropsSnippet.length + 2);
+        const editor = vscode.window.activeTextEditor;
+
+        editor.selection = new vscode.Selection(pos, pos);
+
+        await vscode.commands.executeCommand('vueDiscovery.importFile', getDocPath('components/ComponentWithProps.vue'), 'ComponentWithProps');
+
+        await sleep(50);
+
+        testLineEquals(8, `\t\t${componentWithoutPropsSnippet}${componentWithoutPropsSnippet}`);
+    });
+});


### PR DESCRIPTION
This merge request allows the extension to be used with different file extensions by providing a new configuration option `vueDiscovery.extensions`.

To get Intellisense in html and blade files you can add `"vueDiscovery.extensions": [".html", ".blade.php"]` to your config.

Because I can't be sure what file extensions this will be used with for the moment the extension will assume the components are already globally registered and will not import and register them again. 

close #3 